### PR TITLE
Fixes #22: Flipped GameWorld in GameArea and GameArea only shows GameWorld

### DIFF
--- a/.idea/codeStyles/Project.xml
+++ b/.idea/codeStyles/Project.xml
@@ -1,5 +1,6 @@
 <component name="ProjectCodeStyleConfiguration">
   <code_scheme name="Project" version="173">
+    <option name="LINE_SEPARATOR" value="&#10;" />
     <JetCodeStyleSettings>
       <option name="ALIGN_IN_COLUMNS_CASE_BRANCH" value="true" />
     </JetCodeStyleSettings>

--- a/src/main/kotlin/de/gleex/pltcmd/game/GameWorld.kt
+++ b/src/main/kotlin/de/gleex/pltcmd/game/GameWorld.kt
@@ -15,7 +15,7 @@ import org.hexworks.zircon.internal.game.impl.TopDownProjectionStrategy
  * The game world contains all [MapBlock]s representing the map. It has a visible part and can scroll from [Sector] to sector.
  * It is also capable of translating [Coordinate]s to [Position3D] and vice versa.
  */
-class GameWorld(worldMap: WorldMap):
+class GameWorld(private val worldMap: WorldMap):
         BaseGameArea<Tile, MapBlock>(
                 initialVisibleSize = Size3D.create(Sector.TILE_COUNT, Sector.TILE_COUNT, 1),
                 initialActualSize = Size3D.from2DSize(worldMap.size, 1),
@@ -34,8 +34,8 @@ class GameWorld(worldMap: WorldMap):
         private val log = LoggerFactory.getLogger(GameWorld::class)
     }
 
-    // TODO only works if world is immutable
-    private val topLeftOffset = worldMap.getTopLeftOffset()
+    private val topLeftOffset: Position
+            get() = worldMap.getTopLeftOffset()
 
     init {
         toBlocks(worldMap)

--- a/src/main/kotlin/de/gleex/pltcmd/game/GameWorld.kt
+++ b/src/main/kotlin/de/gleex/pltcmd/game/GameWorld.kt
@@ -55,6 +55,10 @@ class GameWorld(private val worldMap: WorldMap):
         return visibleOffset.toCoordinate()
     }
 
+    /**
+     * Make the given coordinate and ascending ones visible.
+     * If the visible area has the size of a [Sector] and the origin of a [Sector] is given, the full sector will be visible.
+     */
     fun scrollToCoordinate(bottomLeft: Coordinate) {
         val bottomLeftPos = bottomLeft.toPosition()
         val visibleTopLeftPos = bottomLeftPos.withRelativeY(-getMaxVisibleY())
@@ -67,8 +71,11 @@ class GameWorld(private val worldMap: WorldMap):
     // ui size
     private fun getMaxVisibleY() = visibleSize.yLength - 1 // -1 because y is zero-based
 
+    /**
+     * Returns the difference between the origin of the world and the absolute origin (0, 0).
+     * Used to translate the world map coordinates which start with an arbitrary value to our game area coordinates which start with (0, 0).
+     */
     private fun WorldMap.getTopLeftOffset(): Position {
-        // we translate the world map coordinates which start with an arbitrary value to our game area coordinates which start with (0, 0)
         // use origin of world (minimal numeric value of coordinate) to calculate the offset
         return Position.create(-origin.eastingFromLeft, -origin.northingFromBottom)
     }

--- a/src/main/kotlin/de/gleex/pltcmd/game/GameWorld.kt
+++ b/src/main/kotlin/de/gleex/pltcmd/game/GameWorld.kt
@@ -4,7 +4,7 @@ import de.gleex.pltcmd.model.world.Coordinate
 import de.gleex.pltcmd.model.world.Sector
 import de.gleex.pltcmd.model.world.WorldMap
 import org.hexworks.cobalt.logging.api.LoggerFactory
-import org.hexworks.zircon.api.Sizes
+import org.hexworks.zircon.api.data.Position
 import org.hexworks.zircon.api.data.Position3D
 import org.hexworks.zircon.api.data.Size3D
 import org.hexworks.zircon.api.data.Tile
@@ -18,7 +18,7 @@ import org.hexworks.zircon.internal.game.impl.TopDownProjectionStrategy
 class GameWorld(worldMap: WorldMap):
         BaseGameArea<Tile, MapBlock>(
                 initialVisibleSize = Size3D.create(Sector.TILE_COUNT, Sector.TILE_COUNT, 1),
-                initialActualSize = Sizes.from2DTo3D(worldMap.size, 1),
+                initialActualSize = Size3D.from2DSize(worldMap.size, 1),
                 initialContents = mapOf(),
                 projectionStrategy = TopDownProjectionStrategy())
 {
@@ -39,7 +39,7 @@ class GameWorld(worldMap: WorldMap):
 
     init {
         toBlocks(worldMap)
-        log.debug("Created GameWorld with ${worldMap.sectors.size} sectors. Visible size = ${visibleSize()}")
+        log.debug("Created GameWorld with ${worldMap.sectors.size} sectors. Visible size = ${visibleSize}")
     }
 
     private fun toBlocks(worldMap: WorldMap) {
@@ -64,10 +64,10 @@ class GameWorld(worldMap: WorldMap):
     }
 
     // model size
-    private fun getMaxY() = actualSize().yLength - 1 // -1 because y is zero-based
+    private fun getMaxY() = actualSize.yLength - 1 // -1 because y is zero-based
 
     // ui size
-    private fun getMaxVisibleY() = visibleSize().yLength - 1 // -1 because y is zero-based
+    private fun getMaxVisibleY() = visibleSize.yLength - 1 // -1 because y is zero-based
 
     private fun WorldMap.getTopLeftOffset(): Position {
         // we translate the world map coordinates which start with an arbitrary value to our game area coordinates which start with (0, 0)

--- a/src/main/kotlin/de/gleex/pltcmd/game/GameWorld.kt
+++ b/src/main/kotlin/de/gleex/pltcmd/game/GameWorld.kt
@@ -6,16 +6,16 @@ import de.gleex.pltcmd.model.terrain.TerrainType
 import de.gleex.pltcmd.model.world.Coordinate
 import de.gleex.pltcmd.model.world.Sector
 import de.gleex.pltcmd.model.world.WorldMap
-import de.gleex.pltcmd.options.GameOptions
 import org.hexworks.cobalt.logging.api.LoggerFactory
 import org.hexworks.zircon.api.Sizes
 import org.hexworks.zircon.api.builder.game.GameAreaBuilder
+import org.hexworks.zircon.api.data.Position
 import org.hexworks.zircon.api.data.Tile
 import org.hexworks.zircon.api.data.impl.Position3D
 import org.hexworks.zircon.api.game.GameArea
 
-class GameWorld(worldMap: WorldMap): GameArea<Tile, MapBlock> by GameAreaBuilder.newBuilder<Tile, MapBlock>().
-        withActualSize(Sizes.create3DSize(GameOptions.SECTORS_COUNT_H * Sector.TILE_COUNT, GameOptions.SECTORS_COUNT_V * Sector.TILE_COUNT, 1)).
+class GameWorld(worldMap: WorldMap) : GameArea<Tile, MapBlock> by GameAreaBuilder.newBuilder<Tile, MapBlock>().
+        withActualSize(Sizes.from2DTo3D(worldMap.size, 1)).
         withVisibleSize(Sizes.create3DSize(Sector.TILE_COUNT, Sector.TILE_COUNT, 1)).
         withLayersPerBlock(MapBlock.LAYERS_PER_BLOCK).
         withDefaultBlock(MapBlock(Terrain(TerrainType.GRASSLAND, TerrainHeight.ONE))).
@@ -25,30 +25,57 @@ class GameWorld(worldMap: WorldMap): GameArea<Tile, MapBlock> by GameAreaBuilder
         private val log = LoggerFactory.getLogger(GameWorld::class)
     }
 
+    // TODO only works if world is immutable
+    private val topLeftOffset = worldMap.getTopLeftOffset()
+
     init {
-        worldMap.sectors.forEach(::putSector)
+        toBlocks(worldMap)
         log.debug("Created GameWorld with ${worldMap.sectors.size} sectors. Visible size = ${visibleSize()}")
     }
 
-    private fun putSector(sector: Sector) {
-        sector.tiles.forEach {
-            val position = it.coordinate.toPosition()
-            val block = MapBlock(it.terrain)
-            setBlockAt(position, block)
+    private fun toBlocks(worldMap: WorldMap) {
+        worldMap.sectors.forEach { sector ->
+            sector.tiles.forEach {
+                val position = it.coordinate.toPosition()
+                val block = MapBlock(it.terrain)
+                setBlockAt(position, block)
+            }
         }
     }
-
-    private fun Coordinate.toPosition() = Position3D.create(eastingFromLeft, northingFromBottom, 0)
-
-    private fun Position3D.toCoordinate() = Coordinate(x, y)
 
     /** Returns the [Coordinate] of the [Tile] that is visible in the top left corner. */
     fun visibleTopLeftCoordinate(): Coordinate {
         return visibleOffset().toCoordinate()
     }
 
-    fun scrollToCoordinate(coord: Coordinate) {
-        scrollTo3DPosition(coord.toPosition())
+    fun scrollToCoordinate(bottomLeft: Coordinate) {
+        val bottomLeftPos = bottomLeft.toPosition()
+        val visibleTopLeftPos = bottomLeftPos.withRelativeY(-getMaxVisibleY())
+        scrollTo3DPosition(visibleTopLeftPos)
+    }
+
+    // model size
+    private fun getMaxY() = actualSize().yLength - 1 // -1 because y is zero-based
+
+    // ui size
+    private fun getMaxVisibleY() = visibleSize().yLength - 1 // -1 because y is zero-based
+
+    private fun WorldMap.getTopLeftOffset(): Position {
+        // we translate the world map coordinates which start with an arbitrary value to our game area coordinates which start with (0, 0)
+        // use minimal numeric value of coordinate to calculate the offset
+        return Position.create(-origin.eastingFromLeft, -origin.northingFromBottom)
+    }
+
+    private fun Coordinate.toPosition(): Position3D {
+        val translatedPos = Position.create(eastingFromLeft, northingFromBottom) + topLeftOffset
+        // invert y axis
+        return Position3D.from2DPosition(translatedPos.withY(getMaxY() - translatedPos.y))
+    }
+
+    private fun Position3D.toCoordinate(): Coordinate {
+        val translatedPos = to2DPosition() - topLeftOffset
+        // invert y axis
+        return Coordinate(translatedPos.x, translatedPos.y + getMaxY())
     }
 
 }

--- a/src/main/kotlin/de/gleex/pltcmd/game/GameWorld.kt
+++ b/src/main/kotlin/de/gleex/pltcmd/game/GameWorld.kt
@@ -38,17 +38,15 @@ class GameWorld(private val worldMap: WorldMap):
             get() = worldMap.getTopLeftOffset()
 
     init {
-        toBlocks(worldMap)
-        log.debug("Created GameWorld with ${worldMap.sectors.size} sectors. Visible size = ${visibleSize}")
+        worldMap.sectors.forEach(::putSector)
+        log.debug("Created GameWorld with ${worldMap.sectors.size} sectors. Visible size = $visibleSize")
     }
 
-    private fun toBlocks(worldMap: WorldMap) {
-        worldMap.sectors.forEach { sector ->
-            sector.tiles.forEach {
-                val position = it.coordinate.toPosition()
-                val block = MapBlock(it.terrain)
-                setBlockAt(position, block)
-            }
+    private fun putSector(sector: Sector) {
+        sector.tiles.forEach {
+            val position = it.coordinate.toPosition()
+            val block = MapBlock(it.terrain)
+            setBlockAt(position, block)
         }
     }
 
@@ -71,7 +69,7 @@ class GameWorld(private val worldMap: WorldMap):
 
     private fun WorldMap.getTopLeftOffset(): Position {
         // we translate the world map coordinates which start with an arbitrary value to our game area coordinates which start with (0, 0)
-        // use minimal numeric value of coordinate to calculate the offset
+        // use origin of world (minimal numeric value of coordinate) to calculate the offset
         return Position.create(-origin.eastingFromLeft, -origin.northingFromBottom)
     }
 

--- a/src/main/kotlin/de/gleex/pltcmd/model/world/Coordinate.kt
+++ b/src/main/kotlin/de/gleex/pltcmd/model/world/Coordinate.kt
@@ -7,7 +7,7 @@ package de.gleex.pltcmd.model.world
  *
  * It is like the numerical location of the Military Grid Reference System (see https://en.wikipedia.org/wiki/Military_Grid_Reference_System#Numerical_location).
  */
-data class Coordinate(val eastingFromLeft: Int, val northingFromBottom: Int) {
+data class Coordinate(val eastingFromLeft: Int, val northingFromBottom: Int) : Comparable<Coordinate> {
     /**
      * Converts this coordinate to a [MainCoordinate]
      */
@@ -18,5 +18,17 @@ data class Coordinate(val eastingFromLeft: Int, val northingFromBottom: Int) {
 
     /** Creates a new [Coordinate] that is moved by the given amount to the north from this coordinate */
     fun withRelativeNorthing(toNorth: Int) = Coordinate(eastingFromLeft, northingFromBottom + toNorth)
+
+    /**
+     * Sort from most south-west to most north-east. Going line wise first east and then north.
+     * Example: 2|2, 3|2, 1|3
+     */
+    override fun compareTo(other: Coordinate): Int {
+        val northDiff = northingFromBottom - other.northingFromBottom
+        if (northDiff == 0) {
+            return eastingFromLeft - other.eastingFromLeft
+        }
+        return northDiff
+    }
 
 }

--- a/src/main/kotlin/de/gleex/pltcmd/model/world/WorldMap.kt
+++ b/src/main/kotlin/de/gleex/pltcmd/model/world/WorldMap.kt
@@ -8,6 +8,10 @@ import kotlin.math.sqrt
  */
 data class WorldMap(val sectors: Set<Sector>) {
 
+    init {
+        require(sectors.isNotEmpty()) { "WorldMap cannot be empty! Please provide at least one Sector." }
+    }
+
     /** Returns the number of [WorldTile]s per dimension on the map */
     val size: Size
         get() {

--- a/src/main/kotlin/de/gleex/pltcmd/model/world/WorldMap.kt
+++ b/src/main/kotlin/de/gleex/pltcmd/model/world/WorldMap.kt
@@ -1,6 +1,23 @@
 package de.gleex.pltcmd.model.world
 
+import org.hexworks.zircon.api.data.Size
+import kotlin.math.sqrt
+
 /**
  * The world contains all map tiles. The world is divided into [Sector]s.
  */
-data class WorldMap(val sectors: Set<Sector>)
+data class WorldMap(val sectors: Set<Sector>) {
+
+    /** Returns the number of [WorldTile]s per dimension on the map */
+    val size: Size
+        get() {
+            // TODO currently we assume a square world full with sectors. Better check the existing world for what it contains
+            val lengthInSectors = sqrt(sectors.size.toDouble()).toInt()
+            val lengthInTiles = lengthInSectors * Sector.TILE_COUNT
+            return Size.create(lengthInTiles, lengthInTiles)
+        }
+
+    /** the most south-west [Coordinate] of this world */
+    val origin = sectors.minBy { it.origin }!!.origin
+
+}

--- a/src/test/kotlin/de/gleex/pltcmd/model/world/CoordinateTest.kt
+++ b/src/test/kotlin/de/gleex/pltcmd/model/world/CoordinateTest.kt
@@ -1,0 +1,50 @@
+package de.gleex.pltcmd.model.world
+
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Test
+
+internal class CoordinateTest {
+
+    val testCoordinate: Coordinate = Coordinate(123, 345)
+
+    @Test
+    fun toMainCoordinate() {
+        val expected = MainCoordinate(1, 3)
+        assertEquals(expected, testCoordinate.toMainCoordinate())
+    }
+
+    @Test
+    fun withRelativeEasting() {
+        val delta = 789
+        val expected = Coordinate(testCoordinate.eastingFromLeft + delta, testCoordinate.northingFromBottom)
+        assertEquals(expected, testCoordinate.withRelativeEasting(delta))
+    }
+
+    @Test
+    fun withRelativeNorthing() {
+        val delta = 789
+        val expected = Coordinate(testCoordinate.eastingFromLeft, testCoordinate.northingFromBottom + delta)
+        assertEquals(expected, testCoordinate.withRelativeNorthing(delta))
+    }
+
+    @Test
+    fun compareTo() {
+        val otherCoordinate = Coordinate(124, 344)
+        testCompareTo(otherCoordinate, testCoordinate)
+        // proof KDoc
+        val c13 = Coordinate(1,3)
+        val c22 = Coordinate(2,2)
+        val c32 = Coordinate(3,2)
+        testCompareTo(c22, c32)
+        testCompareTo(c32, c13)
+        testCompareTo(c22, c13)
+    }
+
+    private fun testCompareTo(lesserCoordinate: Coordinate, majorCoordinate: Coordinate) {
+        assertEquals(0, lesserCoordinate.compareTo(lesserCoordinate))
+        assertEquals(0, majorCoordinate.compareTo(majorCoordinate))
+        assertEquals(-1, lesserCoordinate.compareTo(majorCoordinate))
+        assertEquals(1, majorCoordinate.compareTo(lesserCoordinate))
+    }
+
+}

--- a/src/test/kotlin/de/gleex/pltcmd/model/world/CoordinateTest.kt
+++ b/src/test/kotlin/de/gleex/pltcmd/model/world/CoordinateTest.kt
@@ -34,7 +34,7 @@ internal class CoordinateTest {
         val expected = Coordinate(testCoordinate.eastingFromLeft + delta, testCoordinate.northingFromBottom)
         val withRelativeEasting = testCoordinate.withRelativeEasting(delta)
         assertEquals(expected, withRelativeEasting)
-        assertTrue("New easting should be bigger") { withRelativeEasting.eastingFromLeft < testCoordinate.eastingFromLeft }
+        assertTrue("New easting should be lower") { withRelativeEasting.eastingFromLeft < testCoordinate.eastingFromLeft }
     }
 
     @Test

--- a/src/test/kotlin/de/gleex/pltcmd/model/world/CoordinateTest.kt
+++ b/src/test/kotlin/de/gleex/pltcmd/model/world/CoordinateTest.kt
@@ -2,6 +2,7 @@ package de.gleex.pltcmd.model.world
 
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Test
+import kotlin.test.assertTrue
 
 internal class CoordinateTest {
 
@@ -25,6 +26,24 @@ internal class CoordinateTest {
         val delta = 789
         val expected = Coordinate(testCoordinate.eastingFromLeft, testCoordinate.northingFromBottom + delta)
         assertEquals(expected, testCoordinate.withRelativeNorthing(delta))
+    }
+
+    @Test
+    fun withNegtiveRelativeEasting() {
+        val delta = -19
+        val expected = Coordinate(testCoordinate.eastingFromLeft + delta, testCoordinate.northingFromBottom)
+        val withRelativeEasting = testCoordinate.withRelativeEasting(delta)
+        assertEquals(expected, withRelativeEasting)
+        assertTrue("New easting should be bigger") { withRelativeEasting.eastingFromLeft < testCoordinate.eastingFromLeft }
+    }
+
+    @Test
+    fun withNegativeRelativeNorthing() {
+        val delta = -198549
+        val expected = Coordinate(testCoordinate.eastingFromLeft, testCoordinate.northingFromBottom + delta)
+        val withRelativeNorthing = testCoordinate.withRelativeNorthing(delta)
+        assertEquals(expected, withRelativeNorthing)
+        assertTrue("New northing should be lower") { withRelativeNorthing.northingFromBottom < testCoordinate.northingFromBottom }
     }
 
     @Test

--- a/src/test/kotlin/de/gleex/pltcmd/model/world/WorldMapTest.kt
+++ b/src/test/kotlin/de/gleex/pltcmd/model/world/WorldMapTest.kt
@@ -7,13 +7,6 @@ import org.junit.jupiter.api.Test
 internal class WorldMapTest {
 
     @Test
-    fun getSizeEmpty() {
-        val expected = Size.create(0, 0)
-        val result = WorldMap(emptySet()).size
-        assertEquals(expected, result)
-    }
-
-    @Test
     fun getSizeSingle() {
         val expected = Size.create(Sector.TILE_COUNT, Sector.TILE_COUNT)
         val result = WorldMap(setOf(createSector(3))).size

--- a/src/test/kotlin/de/gleex/pltcmd/model/world/WorldMapTest.kt
+++ b/src/test/kotlin/de/gleex/pltcmd/model/world/WorldMapTest.kt
@@ -1,0 +1,52 @@
+package de.gleex.pltcmd.model.world
+
+import org.hexworks.zircon.api.data.Size
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Test
+
+internal class WorldMapTest {
+
+    @Test
+    fun getSizeEmpty() {
+        val expected = Size.create(0, 0)
+        val result = WorldMap(emptySet()).size
+        assertEquals(expected, result)
+    }
+
+    @Test
+    fun getSizeSingle() {
+        val expected = Size.create(Sector.TILE_COUNT, Sector.TILE_COUNT)
+        val result = WorldMap(setOf(createSector(3))).size
+        assertEquals(expected, result)
+    }
+
+    @Test
+    fun getSizeCalculated() {
+        testSize(2)
+        testSize(3)
+        testSize(11)
+    }
+
+    private fun testSize(sideLengthInSectors: Int) {
+        val sectors = createSectors(sideLengthInSectors)
+        val expected = Size.create(sideLengthInSectors * Sector.TILE_COUNT, sideLengthInSectors * Sector.TILE_COUNT)
+
+        val result = WorldMap(sectors).size
+
+        assertEquals(expected, result)
+    }
+
+    fun createSectors(sideLength: Int): Set<Sector> {
+        val sectors = mutableSetOf<Sector>()
+        for (i in 0 until (sideLength * sideLength)) {
+            sectors.add(createSector(i))
+        }
+        return sectors
+    }
+
+    fun createSector(index: Int): Sector {
+        val origin = Coordinate(index * 50, index * 50)
+        return Sector.generateAt(origin)
+    }
+
+}


### PR DESCRIPTION
So the game starts with its block position in the top left corner at 0,0 but
the map grid starts in the bottom left corner at an arbitrary coordinate