### PR TITLE
Fixes #28: Drawing coordinates at grid

### DIFF
--- a/src/main/kotlin/de/gleex/pltcmd/main.kt
+++ b/src/main/kotlin/de/gleex/pltcmd/main.kt
@@ -11,7 +11,7 @@ import org.hexworks.zircon.api.SwingApplications
 import org.hexworks.zircon.api.extensions.toScreen
 
 fun main() {
-    val initialOrigin = Coordinate(350, 200)
+    val initialOrigin = Coordinate(0, 200)
     val worldMap = WorldMap(
             setOf(
                     Sector.generateAt(initialOrigin)))

--- a/src/main/kotlin/de/gleex/pltcmd/model/world/Coordinate.kt
+++ b/src/main/kotlin/de/gleex/pltcmd/model/world/Coordinate.kt
@@ -31,11 +31,11 @@ data class Coordinate(val eastingFromLeft: Int, val northingFromBottom: Int) : C
         return northDiff
     }
 
-    override fun toString(): String {
-        val eastingString = toCoordinateText(eastingFromLeft)
-        val northingString = toCoordinateText(northingFromBottom)
-        return "($eastingString|$northingString)"
-    }
+    override fun toString() = "(${formattedEasting()}|${formattedNorthing()})"
+
+    fun formattedEasting() = toCoordinateText(eastingFromLeft)
+
+    fun formattedNorthing() = toCoordinateText(northingFromBottom)
 
     private fun toCoordinateText(coordinateValue: Int): String {
         return if (coordinateValue >= 0) {

--- a/src/main/kotlin/de/gleex/pltcmd/ui/renderers/CoordinateTileString.kt
+++ b/src/main/kotlin/de/gleex/pltcmd/ui/renderers/CoordinateTileString.kt
@@ -53,4 +53,7 @@ open class CoordinateTileString(
     /** Returns the [Position] on which this text starts if centered on the given position. */
     open fun getStartPositionToCenterOn(center: Position) = center.withRelativeX(offsetForCenteredText())
 
+    /** Returns the [Position] on which this text ends if centered on the given position. */
+    open fun getEndPositionToCenterOn(center: Position) = getStartPositionToCenterOn(center).withRelativeX(text.length - 1)
+
 }

--- a/src/main/kotlin/de/gleex/pltcmd/ui/renderers/CoordinateTileString.kt
+++ b/src/main/kotlin/de/gleex/pltcmd/ui/renderers/CoordinateTileString.kt
@@ -12,13 +12,12 @@ import org.hexworks.zircon.api.graphics.TileComposite
  * It can be drawn horizontally or vertically.
  **/
 open class CoordinateTileString(
-        coordinateValue: Int,
+        protected val text: String,
         protected val drawParams: CoordinateDrawParameters = CoordinateDrawParameters(
                 ColorRepository.GRID_COLOR,
                 ColorRepository.COORDINATE_COLOR_HIGHLIGHT_X
         )
 ) : TileComposite {
-    protected val text = coordinateValue.toString()
     private val majorLength = text.length - 2 // 2 = "00" at end (highlight only hundreds and more)
 
     override val size: Size

--- a/src/main/kotlin/de/gleex/pltcmd/ui/renderers/MapCoordinates.kt
+++ b/src/main/kotlin/de/gleex/pltcmd/ui/renderers/MapCoordinates.kt
@@ -67,7 +67,7 @@ class MapCoordinates(
 
     private fun drawCentered(coordinateTiles: CoordinateTileString, center: Position) {
         val textStartPosition = coordinateTiles.getStartPositionToCenterOn(center)
-        val textEndPosition = textStartPosition.withRelativeX(coordinateTiles.width - 1)
+        val textEndPosition = coordinateTiles.getEndPositionToCenterOn(center)
         // prevent truncated text
         if (backend.size.containsPosition(textStartPosition) && backend.size.containsPosition(textEndPosition)) {
             draw(coordinateTiles, textStartPosition)

--- a/src/main/kotlin/de/gleex/pltcmd/ui/renderers/MapCoordinates.kt
+++ b/src/main/kotlin/de/gleex/pltcmd/ui/renderers/MapCoordinates.kt
@@ -67,7 +67,7 @@ class MapCoordinates(
 
     private fun drawCentered(coordinateTiles: CoordinateTileString, center: Position) {
         val textStartPosition = coordinateTiles.getStartPositionToCenterOn(center)
-        val textEndPosition = textStartPosition.withRelativeX(coordinateTiles.width)
+        val textEndPosition = textStartPosition.withRelativeX(coordinateTiles.width - 1)
         // prevent truncated text
         if (backend.size.containsPosition(textStartPosition) && backend.size.containsPosition(textEndPosition)) {
             draw(coordinateTiles, textStartPosition)

--- a/src/main/kotlin/de/gleex/pltcmd/ui/renderers/MapCoordinates.kt
+++ b/src/main/kotlin/de/gleex/pltcmd/ui/renderers/MapCoordinates.kt
@@ -35,12 +35,17 @@ class MapCoordinates(
     }
 
     private fun drawGridCoordinates(topLeftCoordinate: Coordinate, topLeftPos: Position, mapOffset: Position) {
-        // grid coordinates (for square)
-        for (i in 0 until size.width step 5) {
+        // move to next grid marker
+        val offsetToGridX = topLeftCoordinate.eastingFromLeft % MapGrid.GRID_WIDTH
+        for (i in offsetToGridX until size.width - 1 step MapGrid.GRID_WIDTH) {
             // top
             val topCoordinateText = createTopText(topLeftCoordinate, i)
             val topGridPosition = topLeftPos.withRelativeX(i + mapOffset.x)
             drawCentered(topCoordinateText, topGridPosition)
+        }
+
+        val offsetToGridY = topLeftCoordinate.northingFromBottom % MapGrid.GRID_WIDTH
+        for (i in offsetToGridY until size.width - 1 step MapGrid.GRID_WIDTH) {
             // left
             val leftCoordinateText = createLeftText(topLeftCoordinate, i)
             val leftGridPosition = topLeftPos.withRelativeY(i + mapOffset.y)
@@ -62,7 +67,11 @@ class MapCoordinates(
 
     private fun drawCentered(coordinateTiles: CoordinateTileString, center: Position) {
         val textStartPosition = coordinateTiles.getStartPositionToCenterOn(center)
-        draw(coordinateTiles, textStartPosition)
+        val textEndPosition = textStartPosition.withRelativeX(coordinateTiles.width)
+        // prevent truncated text
+        if (backend.size.containsPosition(textStartPosition) && backend.size.containsPosition(textEndPosition)) {
+            draw(coordinateTiles, textStartPosition)
+        }
     }
 
     override fun toString() = "MapCoordinates $backend"

--- a/src/main/kotlin/de/gleex/pltcmd/ui/renderers/MapCoordinates.kt
+++ b/src/main/kotlin/de/gleex/pltcmd/ui/renderers/MapCoordinates.kt
@@ -56,13 +56,13 @@ class MapCoordinates(
     /** Moves the given [Coordinate] by the given offset to the east and creates a drawable text of that coordinate. */
     private fun createTopText(topLeftCoordinate: Coordinate, offsetToEast: Int): CoordinateTileString {
         val topCoordinate = topLeftCoordinate.withRelativeEasting(offsetToEast)
-        return CoordinateTileString(topCoordinate.eastingFromLeft)
+        return CoordinateTileString(topCoordinate.formattedEasting())
     }
 
     /** Moves the given [Coordinate] by the given offset to the south and creates a drawable text of that coordinate. */
     private fun createLeftText(topLeftCoordinate: Coordinate, offsetToSouth: Int): CoordinateTileString {
         val leftCoordinate = topLeftCoordinate.withRelativeNorthing(-offsetToSouth)
-        return VerticalCoordinateTileString(leftCoordinate.northingFromBottom)
+        return VerticalCoordinateTileString(leftCoordinate.formattedNorthing())
     }
 
     private fun drawCentered(coordinateTiles: CoordinateTileString, center: Position) {

--- a/src/main/kotlin/de/gleex/pltcmd/ui/renderers/MapGrid.kt
+++ b/src/main/kotlin/de/gleex/pltcmd/ui/renderers/MapGrid.kt
@@ -24,6 +24,10 @@ class MapGrid(
                 .build())
     : TileGraphics by backend {
 
+    companion object {
+        const val GRID_WIDTH = 5
+    }
+
     init {
         val topLeftPos = size.fetchTopLeftPosition()
         val majorGridMarker =
@@ -68,19 +72,32 @@ class MapGrid(
     }
 
     private fun drawGridMarkers(topLeftPos: Position, majorGridMarker: TileGraphics, minorGridMarker: TileGraphics) {
-        // grid markers (for square)
-        for (i in 1 until size.width step 5) {
-            val gridMarker = if ((i - 1) % 10 == 0) majorGridMarker else minorGridMarker
-            val top = topLeftPos.withRelativeX(i)
+        // grid markers (for square), start at 1 to skipt the top left corner
+        for (i in 0 until size.width step GRID_WIDTH) {
+            val gridMarker = if (i % (GRID_WIDTH * 2) == 0) majorGridMarker else minorGridMarker
+            val top = topLeftPos.withRelativeX(i + 1) // 1 = with of vertical bar that is already used by this grid
             val left = topLeftPos.withRelativeY(i)
             // top
-            draw(gridMarker, top)
+            if (!top.isCorner()) draw(gridMarker, top)
             // left
-            draw(gridMarker, left)
+            if (!left.isCorner()) draw(gridMarker, left)
             // bottom
-            draw(gridMarker, top.withRelativeY(size.height - 1))
+            val bottom = top.withRelativeY(size.height - 1)
+            if (!bottom.isCorner()) draw(gridMarker, bottom)
             // right
-            draw(gridMarker, left.withRelativeX(size.width - 1))
+            val right = left.withRelativeX(size.width - 1)
+            if (!right.isCorner()) draw(gridMarker, right)
+        }
+    }
+
+    private fun Position.isCorner(): Boolean {
+        return when (x) {
+            0, size.width - 1 -> {
+                y == 0 || y == size.width - 1
+            }
+            else              -> {
+                false
+            }
         }
     }
 

--- a/src/main/kotlin/de/gleex/pltcmd/ui/renderers/MapGrid.kt
+++ b/src/main/kotlin/de/gleex/pltcmd/ui/renderers/MapGrid.kt
@@ -28,6 +28,9 @@ class MapGrid(
         const val GRID_WIDTH = 5
     }
 
+    // we assume that the map has a grid crossing at Position(1,0) or in other words: A full sector is visible with its origin in the bottom left corner.
+    private val mapToDrawOffset = Position.create(1,0)
+
     init {
         val topLeftPos = size.fetchTopLeftPosition()
         val majorGridMarker =
@@ -72,11 +75,11 @@ class MapGrid(
     }
 
     private fun drawGridMarkers(topLeftPos: Position, majorGridMarker: TileGraphics, minorGridMarker: TileGraphics) {
-        // grid markers (for square), start at 1 to skipt the top left corner
+        // grid markers (for square)
         for (i in 0 until size.width step GRID_WIDTH) {
             val gridMarker = if (i % (GRID_WIDTH * 2) == 0) majorGridMarker else minorGridMarker
-            val top = topLeftPos.withRelativeX(i + 1) // 1 = with of vertical bar that is already used by this grid
-            val left = topLeftPos.withRelativeY(i)
+            val top = topLeftPos.withRelativeX(i + mapToDrawOffset.x)
+            val left = topLeftPos.withRelativeY(i + mapToDrawOffset.y)
             // top
             if (!top.isCorner()) draw(gridMarker, top)
             // left

--- a/src/main/kotlin/de/gleex/pltcmd/ui/renderers/VerticalCoordinateTileString.kt
+++ b/src/main/kotlin/de/gleex/pltcmd/ui/renderers/VerticalCoordinateTileString.kt
@@ -5,12 +5,12 @@ import org.hexworks.zircon.api.data.Position
 import org.hexworks.zircon.api.data.Size
 
 class VerticalCoordinateTileString(
-        coordinateValue: Int,
+        text: String,
         drawParams: CoordinateDrawParameters = CoordinateDrawParameters(
                 ColorRepository.GRID_COLOR,
                 ColorRepository.COORDINATE_COLOR_HIGHLIGHT_Y
         )
-) : CoordinateTileString(coordinateValue, drawParams) {
+) : CoordinateTileString(text, drawParams) {
 
     override val size: Size
         get() = Size.create(1, text.length)

--- a/src/main/kotlin/de/gleex/pltcmd/ui/renderers/VerticalCoordinateTileString.kt
+++ b/src/main/kotlin/de/gleex/pltcmd/ui/renderers/VerticalCoordinateTileString.kt
@@ -19,4 +19,6 @@ class VerticalCoordinateTileString(
 
     override fun getStartPositionToCenterOn(center: Position) = center.withRelativeY(offsetForCenteredText())
 
+    override fun getEndPositionToCenterOn(center: Position) = getStartPositionToCenterOn(center).withRelativeY(text.length - 1)
+
 }


### PR DESCRIPTION
Align map decorations to map coordinates, don't draw markers at corners