### PR TITLE
Fixed #48: Start TypeFiller at relative highest points, not absolute

### DIFF
--- a/src/main/kotlin/de/gleex/pltcmd/model/mapgenerators/intermediate/TypeFiller.kt
+++ b/src/main/kotlin/de/gleex/pltcmd/model/mapgenerators/intermediate/TypeFiller.kt
@@ -5,8 +5,10 @@ import de.gleex.pltcmd.model.mapgenerators.data.MutableWorld
 import de.gleex.pltcmd.model.terrain.TerrainHeight
 import de.gleex.pltcmd.model.terrain.TerrainType
 import de.gleex.pltcmd.model.terrain.TerrainType.*
+import de.gleex.pltcmd.model.world.Coordinate
 import de.gleex.pltcmd.model.world.CoordinateArea
 import org.hexworks.cobalt.logging.api.LoggerFactory
+import java.util.*
 import kotlin.random.Random
 
 class TypeFiller(override val rand: Random, override val context: GenerationContext) : IntermediateGenerator() {
@@ -20,31 +22,50 @@ class TypeFiller(override val rand: Random, override val context: GenerationCont
 
         log.debug("Found ${allTiles.size} tiles that need a terrain type")
 
-        // manually create mountain tops
-        allTiles.
-            filter { mutableWorld.heightAt(it) == TerrainHeight.MAX }.
-            forEach {
-                mutableWorld[it] = MOUNTAIN
-                processedTiles.add(it)
-            }
-
-        log.debug("Set ${processedTiles.size} mountain tops, working downwards from there...")
+        // start with highest points in the world
+        val highestPoints = findHighestPoints(allTiles, mutableWorld)
+        highestPoints.forEach {
+            fillTypeBasedOnHeight(it, MOUNTAIN, mutableWorld)
+            processedTiles.add(it)
+        }
+        log.debug("Started with ${processedTiles.size} highest points, working downwards from there...")
 
         workFrontier(processedTiles, {currentCoordinate ->
             mutableWorld.neighborsOf(currentCoordinate).
                 filter { it in area && mutableWorld.typeAt(it) == null && it.isNotProcessed() }.
                 forEach { neighbor ->
-                    val probabilities = probabilities(mutableWorld.heightAt(neighbor), mutableWorld.typeAt(currentCoordinate))
-                    mutableWorld[neighbor] = generateType(probabilities)
+                    fillTypeBasedOnHeight(neighbor, mutableWorld.typeAt(currentCoordinate), mutableWorld)
                     neighbor.addToNextFrontier()
                 }
         })
+    }
+
+    private fun findHighestPoints(allTiles: SortedSet<Coordinate>, mutableWorld: MutableWorld): MutableSet<Coordinate> {
+        val mountainTops = mutableSetOf<Coordinate>()
+        var maxHeight = TerrainHeight.MIN
+        for (tile in allTiles) {
+            val heightAtTile = mutableWorld.heightAt(tile) ?: continue
+            if (heightAtTile > maxHeight) {
+                maxHeight = heightAtTile
+                mountainTops.clear()
+            }
+            if (heightAtTile == maxHeight) {
+                mountainTops.add(tile)
+            }
+        }
+        return mountainTops
+    }
+
+    private fun fillTypeBasedOnHeight(tileToFill: Coordinate, neighborType: TerrainType?, mutableWorld: MutableWorld) {
+        val probabilities = probabilities(mutableWorld.heightAt(tileToFill), neighborType)
+        mutableWorld[tileToFill] = generateType(probabilities)
     }
 
     private fun probabilities(terrainHeight: TerrainHeight?, neighborType: TerrainType?): Map<Double, TerrainType> {
         val richVegetation = context.vegetation
         val poorVegetation = 1.0 - richVegetation
         return when (terrainHeight) {
+            TerrainHeight.TEN   -> mapOf(1.0 to MOUNTAIN)
             TerrainHeight.NINE  -> mapOf(
                     0.7 to MOUNTAIN,
                     0.9 to HILL,


### PR DESCRIPTION
So terrain types will also be filled if no TerrainHeight.MAX exists in the world