### PR TITLE
Resolves #59: Require highest version of dependencies

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -137,15 +137,12 @@
 				<version>3.0.0-M3</version>
 				<executions>
 					<execution>
-						<id>enforce-consistent-versions</id>
+						<id>enforce-upper-bound-deps</id>
 						<goals>
 							<goal>enforce</goal>
 						</goals>
 						<configuration>
 							<rules>
-								<requireMavenVersion>
-									<version>3</version>
-								</requireMavenVersion>
 								<requireUpperBoundDeps />
 							</rules>
 						</configuration>

--- a/pom.xml
+++ b/pom.xml
@@ -52,14 +52,28 @@
 
 	<dependencies>
 		<dependency>
-			<groupId>org.hexworks.cobalt</groupId>
-			<artifactId>cobalt.core-jvm</artifactId>
-			<version>${cobalt.version}</version>
-		</dependency>
-		<dependency>
 			<groupId>org.jetbrains.kotlin</groupId>
 			<artifactId>kotlin-stdlib</artifactId>
 			<version>${kotlin.version}</version>
+		</dependency>
+		<dependency>
+			<groupId>org.hexworks.cobalt</groupId>
+			<artifactId>cobalt.core-jvm</artifactId>
+			<version>${cobalt.version}</version>
+			<exclusions>
+				<exclusion>
+					<groupId>org.jetbrains.kotlin</groupId>
+					<artifactId>kotlin-stdlib</artifactId>
+				</exclusion>
+				<exclusion>
+					<groupId>org.jetbrains.kotlin</groupId>
+					<artifactId>kotlin-stdlib-jdk8</artifactId>
+				</exclusion>
+				<exclusion>
+					<groupId>org.jetbrains.kotlin</groupId>
+					<artifactId>kotlin-stdlib-common</artifactId>
+				</exclusion>
+			</exclusions>
 		</dependency>
 		<!-- test dependencies -->
 		<dependency>
@@ -73,6 +87,12 @@
 			<artifactId>kotlintest-runner-junit5</artifactId>
 			<version>${kotest.version}</version>
 			<scope>test</scope>
+			<exclusions>
+				<exclusion>
+					<groupId>org.jetbrains.kotlin</groupId>
+					<artifactId>kotlin-stdlib</artifactId>
+				</exclusion>
+			</exclusions>
 		</dependency>
 	</dependencies>
 

--- a/pom.xml
+++ b/pom.xml
@@ -36,6 +36,7 @@
 		<!-- Should match the version used by Zircon -->
 		<cobalt.version>2020.0.15-PREVIEW</cobalt.version>
 
+		<jupiter.version>5.7.0-M1</jupiter.version>
 		<kotest.version>3.4.2</kotest.version>
 	</properties>
 
@@ -75,6 +76,11 @@
 				</exclusion>
 			</exclusions>
 		</dependency>
+		<dependency>
+			<groupId>org.junit.jupiter</groupId>
+			<artifactId>junit-jupiter-api</artifactId>
+			<version>${jupiter.version}</version>
+		</dependency>
 		<!-- test dependencies -->
 		<dependency>
 			<groupId>org.jetbrains.kotlin</groupId>
@@ -102,6 +108,12 @@
 				<groupId>org.hexworks.zircon</groupId>
 				<artifactId>zircon.core-jvm</artifactId>
 				<version>${zircon.version}</version>
+				<exclusions>
+					<exclusion>
+						<groupId>org.jetbrains.kotlin</groupId>
+						<artifactId>kotlin-stdlib-common</artifactId>
+					</exclusion>
+				</exclusions>
 			</dependency>
 			<dependency>
 				<groupId>org.hexworks.zircon</groupId>
@@ -154,7 +166,7 @@
 								<requireMavenVersion>
 									<version>3</version>
 								</requireMavenVersion>
-								<dependencyConvergence/>
+								<requireUpperBoundDeps/>
 							</rules>
 						</configuration>
 					</execution>

--- a/pom.xml
+++ b/pom.xml
@@ -61,20 +61,6 @@
 			<groupId>org.hexworks.cobalt</groupId>
 			<artifactId>cobalt.core-jvm</artifactId>
 			<version>${cobalt.version}</version>
-			<exclusions>
-				<exclusion>
-					<groupId>org.jetbrains.kotlin</groupId>
-					<artifactId>kotlin-stdlib</artifactId>
-				</exclusion>
-				<exclusion>
-					<groupId>org.jetbrains.kotlin</groupId>
-					<artifactId>kotlin-stdlib-jdk8</artifactId>
-				</exclusion>
-				<exclusion>
-					<groupId>org.jetbrains.kotlin</groupId>
-					<artifactId>kotlin-stdlib-common</artifactId>
-				</exclusion>
-			</exclusions>
 		</dependency>
 		<dependency>
 			<groupId>org.junit.jupiter</groupId>
@@ -93,12 +79,6 @@
 			<artifactId>kotlintest-runner-junit5</artifactId>
 			<version>${kotest.version}</version>
 			<scope>test</scope>
-			<exclusions>
-				<exclusion>
-					<groupId>org.jetbrains.kotlin</groupId>
-					<artifactId>kotlin-stdlib</artifactId>
-				</exclusion>
-			</exclusions>
 		</dependency>
 	</dependencies>
 
@@ -166,7 +146,7 @@
 								<requireMavenVersion>
 									<version>3</version>
 								</requireMavenVersion>
-								<requireUpperBoundDeps/>
+								<requireUpperBoundDeps />
 							</rules>
 						</configuration>
 					</execution>

--- a/pom.xml
+++ b/pom.xml
@@ -82,25 +82,11 @@
 				<groupId>org.hexworks.zircon</groupId>
 				<artifactId>zircon.core-jvm</artifactId>
 				<version>${zircon.version}</version>
-				<exclusions>
-					<exclusion>
-						<!-- we already have a direct dependency to cobalt -->
-						<groupId>org.hexworks.cobalt</groupId>
-						<artifactId>cobalt.core-jvm</artifactId>
-					</exclusion>
-				</exclusions>
 			</dependency>
 			<dependency>
 				<groupId>org.hexworks.zircon</groupId>
 				<artifactId>zircon.jvm.swing</artifactId>
 				<version>${zircon.version}</version>
-				<exclusions>
-					<exclusion>
-						<!-- we already have a direct dependency to cobalt -->
-						<groupId>org.hexworks.cobalt</groupId>
-						<artifactId>cobalt.core-jvm</artifactId>
-					</exclusion>
-				</exclusions>
 			</dependency>
 		</dependencies>
 	</dependencyManagement>
@@ -132,6 +118,27 @@
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-surefire-plugin</artifactId>
 				<version>3.0.0-M4</version>
+			</plugin>
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-enforcer-plugin</artifactId>
+				<version>3.0.0-M3</version>
+				<executions>
+					<execution>
+						<id>enforce-consistent-versions</id>
+						<goals>
+							<goal>enforce</goal>
+						</goals>
+						<configuration>
+							<rules>
+								<requireMavenVersion>
+									<version>3</version>
+								</requireMavenVersion>
+								<dependencyConvergence/>
+							</rules>
+						</configuration>
+					</execution>
+				</executions>
 			</plugin>
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>


### PR DESCRIPTION
Using maven enforcer plugin to ensure that the newest version is taken into account.