### PR TITLE
Resolves #145 entities merge their knowledge into comrades

### DIFF
--- a/game/engine/src/main/kotlin/de/gleex/pltcmd/game/engine/attributes/memory/KnownTerrain.kt
+++ b/game/engine/src/main/kotlin/de/gleex/pltcmd/game/engine/attributes/memory/KnownTerrain.kt
@@ -22,6 +22,10 @@ class KnownTerrain internal constructor(knownTile: WorldTile, isRevealed: Boolea
     /** The [Coordinate] of this [KnownTerrain]. It is always "the truth" independent of the revealed state. */
     val coordinate: Coordinate
         get() = origin.coordinate
+
+    override fun copy(): KnownTerrain {
+        return KnownTerrain(origin, revealed)
+    }
 }
 
 /**

--- a/game/engine/src/main/kotlin/de/gleex/pltcmd/game/engine/attributes/memory/KnownWorld.kt
+++ b/game/engine/src/main/kotlin/de/gleex/pltcmd/game/engine/attributes/memory/KnownWorld.kt
@@ -12,17 +12,17 @@ import java.util.*
  * Knowledge about the [WorldArea] defining the whole [WorldMap]. It is initialized as completely unrevealed
  * and get revealed over time.
  */
-class KnownWorld(world: WorldMap) : Known<WorldArea, KnownWorld> {
+class KnownWorld(override val origin: WorldArea) : Known<WorldArea, KnownWorld> {
 
-    override val origin: WorldArea = world.asWorldArea()
+    constructor(world: WorldMap) : this(world.asWorldArea())
 
     /**
      * All not yet revealed (aka. unknown) [Coordinate]s.
      */
     private val unrevealed: SortedSet<Coordinate> =
         origin
-            // create a local copy
-            .toSortedSet()
+        // create a local copy
+        .toSortedSet()
 
     /**
      * @return the [KnownTerrain] at the given location.
@@ -59,6 +59,10 @@ class KnownWorld(world: WorldMap) : Known<WorldArea, KnownWorld> {
     override fun mergeWith(other: KnownWorld): Boolean {
         return unrevealed
             .removeAll { it !in other.unrevealed }
+    }
+
+    override fun copy(): KnownWorld {
+        return KnownWorld(origin)
     }
 
     /**

--- a/game/engine/src/main/kotlin/de/gleex/pltcmd/game/engine/attributes/memory/KnownWorld.kt
+++ b/game/engine/src/main/kotlin/de/gleex/pltcmd/game/engine/attributes/memory/KnownWorld.kt
@@ -21,8 +21,8 @@ class KnownWorld(override val origin: WorldArea) : Known<WorldArea, KnownWorld> 
      */
     private val unrevealed: SortedSet<Coordinate> =
         origin
-        // create a local copy
-        .toSortedSet()
+            // create a local copy
+            .toSortedSet()
 
     /**
      * @return the [KnownTerrain] at the given location.

--- a/game/engine/src/main/kotlin/de/gleex/pltcmd/game/engine/attributes/memory/Memory.kt
+++ b/game/engine/src/main/kotlin/de/gleex/pltcmd/game/engine/attributes/memory/Memory.kt
@@ -12,4 +12,16 @@ import org.hexworks.amethyst.api.base.BaseAttribute
 class Memory(world: WorldMap): BaseAttribute() {
     val knownWorld: KnownWorld = KnownWorld(world)
     val knownContacts = Knowledge<ElementEntity, KnownContact>()
+
+    /**
+     * Merges [other] into this memory.
+     * See Known.mergeWith() and [Knowledge.mergeWith]
+     **/
+    fun mergeWith(other: Memory): Boolean {
+        var updated = false
+        knownWorld.mergeWith(other.knownWorld).also { updated = updated || it }
+        knownContacts.mergeWith(other.knownContacts).also { updated = updated || it }
+        return updated
+    }
+
 }

--- a/game/engine/src/main/kotlin/de/gleex/pltcmd/game/engine/attributes/memory/elements/KnownContact.kt
+++ b/game/engine/src/main/kotlin/de/gleex/pltcmd/game/engine/attributes/memory/elements/KnownContact.kt
@@ -34,6 +34,10 @@ class KnownContact(private val reporter: ElementEntity, contact: ElementEntity, 
         get() = revealAt(KnowledgeGrade.LOW) { it.element.rung }
     val unitCount: Maybe<Int>
         get() = revealAt(KnowledgeGrade.HIGH) { it.element.totalUnits }
+
+    override fun copy(): KnownContact {
+        return KnownContact(reporter, origin, revealed)
+    }
 }
 
 /**

--- a/game/engine/src/main/kotlin/de/gleex/pltcmd/game/engine/entities/EntityFactory.kt
+++ b/game/engine/src/main/kotlin/de/gleex/pltcmd/game/engine/entities/EntityFactory.kt
@@ -59,7 +59,7 @@ object EntityFactory {
             behaviors(
                 Communicating,
                 LookingAround,
-                TransferMemory
+                SharingKnowledge
             )
             facets(
                 ConversationSender,
@@ -110,7 +110,7 @@ object EntityFactory {
         val behaviors: MutableList<Behavior<GameContext>> = mutableListOf(
             IntentPursuing,
             LookingAround,
-            TransferMemory,
+            SharingKnowledge,
             MovingForOneMinute,
             Communicating,
             Fighting

--- a/game/engine/src/main/kotlin/de/gleex/pltcmd/game/engine/entities/EntityFactory.kt
+++ b/game/engine/src/main/kotlin/de/gleex/pltcmd/game/engine/entities/EntityFactory.kt
@@ -58,7 +58,8 @@ object EntityFactory {
             )
             behaviors(
                 Communicating,
-                LookingAround
+                LookingAround,
+                TransferMemory
             )
             facets(
                 ConversationSender,
@@ -109,6 +110,7 @@ object EntityFactory {
         val behaviors: MutableList<Behavior<GameContext>> = mutableListOf(
             IntentPursuing,
             LookingAround,
+            TransferMemory,
             MovingForOneMinute,
             Communicating,
             Fighting

--- a/game/engine/src/main/kotlin/de/gleex/pltcmd/game/engine/entities/types/Positionable.kt
+++ b/game/engine/src/main/kotlin/de/gleex/pltcmd/game/engine/entities/types/Positionable.kt
@@ -1,13 +1,16 @@
 package de.gleex.pltcmd.game.engine.entities.types
 
 import de.gleex.pltcmd.game.engine.attributes.PositionAttribute
+import de.gleex.pltcmd.game.engine.extensions.AnyGameEntity
 import de.gleex.pltcmd.game.engine.extensions.GameEntity
 import de.gleex.pltcmd.game.engine.extensions.getAttribute
+import de.gleex.pltcmd.game.engine.extensions.tryCastTo
 import de.gleex.pltcmd.model.world.coordinate.Coordinate
 import org.hexworks.amethyst.api.entity.EntityType
 import org.hexworks.cobalt.databinding.api.extension.toProperty
 import org.hexworks.cobalt.databinding.api.property.Property
 import org.hexworks.cobalt.databinding.api.value.ObservableValue
+import org.hexworks.cobalt.datatypes.Maybe
 
 /**
  * This file contains code for entities that have the [PositionAttribute].
@@ -30,3 +33,12 @@ var PositionableEntity.currentPosition: Coordinate
     internal set(value) {
         position = value.toProperty()
     }
+
+/**
+ * Invokes [whenPositionable] if this entity is an [PositionableEntity]. When the type is not [Positionable],
+ * [Maybe.empty] is returned.
+ *
+ * @param R the type that is returned by [whenPositionable]
+ */
+fun <R> AnyGameEntity.asPositionableEntity(whenPositionable: (PositionableEntity) -> R): Maybe<R> =
+    tryCastTo<PositionableEntity, Positionable, R>(whenPositionable)

--- a/game/engine/src/main/kotlin/de/gleex/pltcmd/game/engine/entities/types/Remembering.kt
+++ b/game/engine/src/main/kotlin/de/gleex/pltcmd/game/engine/entities/types/Remembering.kt
@@ -38,6 +38,14 @@ fun RememberingEntity.rememberRevealed(tilesToReveal: CoordinateArea) {
 }
 
 /**
+ * Gives all knowledge of others memory to this entity.
+ * @return true if at least one additional information was added to this memory
+ **/
+fun RememberingEntity.transferMemoryFrom(other: RememberingEntity): Boolean {
+    return memory.mergeWith(other.memory)
+}
+
+/**
  * Invokes [whenRemembering] if this entity is an [RememberingEntity]. When the type is not [Remembering],
  * [Maybe.empty] is returned.
  *

--- a/game/engine/src/main/kotlin/de/gleex/pltcmd/game/engine/systems/behaviours/SharingKnowledge.kt
+++ b/game/engine/src/main/kotlin/de/gleex/pltcmd/game/engine/systems/behaviours/SharingKnowledge.kt
@@ -17,7 +17,7 @@ private val log = KotlinLogging.logger {}
 /**
  * If two or more entities of the same faction are on the same tile, the updated entity sends its knowledge to the others.
  */
-internal object TransferMemory :
+internal object SharingKnowledge :
     BaseBehavior<GameContext>(PositionAttribute::class, FactionAttribute::class, Memory::class) {
 
     override suspend fun update(entity: Entity<EntityType, GameContext>, context: GameContext): Boolean {

--- a/game/engine/src/main/kotlin/de/gleex/pltcmd/game/engine/systems/behaviours/TransferMemory.kt
+++ b/game/engine/src/main/kotlin/de/gleex/pltcmd/game/engine/systems/behaviours/TransferMemory.kt
@@ -1,0 +1,62 @@
+package de.gleex.pltcmd.game.engine.systems.behaviours
+
+import de.gleex.pltcmd.game.engine.GameContext
+import de.gleex.pltcmd.game.engine.attributes.FactionAttribute
+import de.gleex.pltcmd.game.engine.attributes.PositionAttribute
+import de.gleex.pltcmd.game.engine.attributes.memory.Memory
+import de.gleex.pltcmd.game.engine.entities.EntitySet
+import de.gleex.pltcmd.game.engine.entities.types.*
+import mu.KotlinLogging
+import org.hexworks.amethyst.api.base.BaseBehavior
+import org.hexworks.amethyst.api.entity.Entity
+import org.hexworks.amethyst.api.entity.EntityType
+import kotlin.system.measureTimeMillis
+
+private val log = KotlinLogging.logger {}
+
+/**
+ * If two entities of the same faction are on the same tile they transfer their knowledge to each other.
+ */
+internal object TransferMemory :
+    BaseBehavior<GameContext>(PositionAttribute::class, FactionAttribute::class, Memory::class) {
+
+    override suspend fun update(entity: Entity<EntityType, GameContext>, context: GameContext): Boolean {
+        return entity.asPositionableEntity { toUpdate ->
+            toUpdate.comradesAtPosition(context.entities)
+                .exchangeKnowledge()
+            true
+        }.orElse(false)
+    }
+
+}
+
+/**
+ * Returns [RememberingEntity]s at the same position that belong to the same faction as this entity.
+ */
+internal fun PositionableEntity.comradesAtPosition(entities: EntitySet<EntityType>): EntitySet<Remembering> {
+    val myPosition = currentPosition
+    val myFaction = asFactionEntity { it.faction }.get()
+    val comradesAtPosition = entities.filterTyped<Remembering> { other ->
+        other != this
+                && other.asPositionableEntity { it.currentPosition == myPosition }.orElse(false)
+                && other.asFactionEntity { it.faction == myFaction }.orElse(false)
+    }
+    return comradesAtPosition
+}
+
+/**
+ * Each entity updates the memory of each other entity.
+ */
+internal fun EntitySet<Remembering>.exchangeKnowledge() {
+    measureTimeMillis {
+        // cartesian product
+        forEach { first ->
+            forEach { second ->
+                first.transferMemoryFrom(second)
+                second.transferMemoryFrom(first)
+            }
+        }
+    }.also { duration ->
+        log.debug { "merging memories of $size entities took $duration ms" }
+    }
+}

--- a/util/knowledge/src/main/kotlin/de/gleex/pltcmd/util/knowledge/Knowledge.kt
+++ b/util/knowledge/src/main/kotlin/de/gleex/pltcmd/util/knowledge/Knowledge.kt
@@ -6,7 +6,7 @@ import org.hexworks.cobalt.databinding.api.extension.toProperty
 /**
  * A collection of [Known] things of the same type.
  */
-class Knowledge<T: Any, K: Known<T, K>> {
+class Knowledge<T : Any, K : Known<T, K>> {
 
     private val _knownThings: ListProperty<K> = listOf<K>().toProperty()
 
@@ -33,10 +33,11 @@ class Knowledge<T: Any, K: Known<T, K>> {
 
     /**
      * Merges [other] into this knowledge. Everything in [other] will afterwards be obsolete because
-     * for every known thing in [other] [update] will be called.
+     * for every known thing in [other] function [update] will be called.
      */
-    fun mergeWith(other: Knowledge<T, K>) =
+    fun mergeWith(other: Knowledge<T, K>): Boolean =
         other
             .knownThings
-            .forEach{ this.update(it) }
+            .map { this.update(it) }
+            .reduce { a, b -> a || b }
 }

--- a/util/knowledge/src/main/kotlin/de/gleex/pltcmd/util/knowledge/Knowledge.kt
+++ b/util/knowledge/src/main/kotlin/de/gleex/pltcmd/util/knowledge/Knowledge.kt
@@ -25,7 +25,7 @@ class Knowledge<T : Any, K : Known<T, K>> {
     infix fun update(newKnowledge: K): Boolean {
         return get(newKnowledge.origin)
             ?.mergeWith(newKnowledge)
-            ?: _knownThings.updateValue(_knownThings.add(newKnowledge)).successful
+            ?: _knownThings.updateValue(_knownThings.add(newKnowledge.copy())).successful
     }
 
     operator fun get(origin: T) =
@@ -39,5 +39,5 @@ class Knowledge<T : Any, K : Known<T, K>> {
         other
             .knownThings
             .map { this.update(it) }
-            .reduce { a, b -> a || b }
+            .reduceOrNull { a, b -> a || b } ?: false
 }

--- a/util/knowledge/src/main/kotlin/de/gleex/pltcmd/util/knowledge/Knowledge.kt
+++ b/util/knowledge/src/main/kotlin/de/gleex/pltcmd/util/knowledge/Knowledge.kt
@@ -39,5 +39,5 @@ class Knowledge<T : Any, K : Known<T, K>> {
         other
             .knownThings
             .map { this.update(it) }
-            .reduceOrNull { a, b -> a || b } ?: false
+            .any { it }
 }

--- a/util/knowledge/src/main/kotlin/de/gleex/pltcmd/util/knowledge/Known.kt
+++ b/util/knowledge/src/main/kotlin/de/gleex/pltcmd/util/knowledge/Known.kt
@@ -6,7 +6,7 @@ package de.gleex.pltcmd.util.knowledge
  * @param T the type of the underlying [origin] (the "truth")
  * @param SELF the actual type of an implementing class so that methods can return
  */
-interface Known<out T: Any, in SELF: Known<T, SELF>> {
+interface Known<out T: Any, SELF: Known<T, SELF>> {
     /**
      * The underlying origin of this knowledge bit. When fully revealed, its values will be accessed directly.
      * Otherwise wrong or missing information may be returned.
@@ -23,4 +23,9 @@ interface Known<out T: Any, in SELF: Known<T, SELF>> {
      * @return true if this object was updated with information from [other]
      */
     infix fun mergeWith(other: SELF): Boolean
+
+    /**
+     * Create a copy with the same state as this [Known].
+     */
+    fun copy(): SELF
 }

--- a/util/knowledge/src/test/kotlin/de/gleex/pltcmd/util/knowledge/TestingKnowledgeByGrade.kt
+++ b/util/knowledge/src/test/kotlin/de/gleex/pltcmd/util/knowledge/TestingKnowledgeByGrade.kt
@@ -4,4 +4,9 @@ package de.gleex.pltcmd.util.knowledge
  * Contains the knowledge of a [String].
  */
 class TestingKnowledgeByGrade(knownBit: String, grade: KnowledgeGrade) :
-    KnownByGrade<String, TestingKnowledgeByGrade>(knownBit, grade)
+    KnownByGrade<String, TestingKnowledgeByGrade>(knownBit, grade) {
+
+    override fun copy(): TestingKnowledgeByGrade {
+        return TestingKnowledgeByGrade(origin, revealed)
+    }
+}


### PR DESCRIPTION
If two or more entities of the same faction are on the same tile, the updated entity sends its knowledge to the others.