### PR TITLE
Resolves #136 fix coroutines usage

### DIFF
--- a/game/engine/src/main/kotlin/de/gleex/pltcmd/game/engine/Game.kt
+++ b/game/engine/src/main/kotlin/de/gleex/pltcmd/game/engine/Game.kt
@@ -41,6 +41,7 @@ data class Game(val engine: Engine<GameContext>, val world: WorldMap, val player
     private var previousUpdate: Job? = null
 
     init {
+        // TODO implement better handling of ticks and engine updates
         globalEventBus.subscribeToTicks {
             if (previousUpdate?.isActive == true) {
                 log.warn { "processing of previous tick has not finished yet! Waiting before doing tick #${it.id}" }

--- a/game/engine/src/main/kotlin/de/gleex/pltcmd/game/engine/Game.kt
+++ b/game/engine/src/main/kotlin/de/gleex/pltcmd/game/engine/Game.kt
@@ -63,8 +63,10 @@ data class Game(val engine: Engine<GameContext>, val world: WorldMap, val player
     fun <T : EntityType> addEntity(entity: GameEntity<T>) = entity.also {
         engine.addEntity(it)
         allEntities.add(it)
-        entity.asElementEntity { element ->
-            removeOnDefeat(element)
+        runBlocking {
+            entity.asElementEntity { element ->
+                removeOnDefeat(element)
+            }
         }
     }
 

--- a/game/engine/src/main/kotlin/de/gleex/pltcmd/game/engine/entities/types/Combatant.kt
+++ b/game/engine/src/main/kotlin/de/gleex/pltcmd/game/engine/entities/types/Combatant.kt
@@ -12,7 +12,6 @@ import mu.KotlinLogging
 import kotlin.random.Random
 import kotlin.time.Duration
 import kotlin.time.DurationUnit
-import kotlin.time.ExperimentalTime
 
 /**
  * This file contains code for entities that have the [ShootersAttribute].
@@ -59,7 +58,6 @@ internal fun CombatantEntity.attack(target: CombatantEntity, random: Random) {
  * @param range in meters
  * @return number of all hits in the given time.
  **/
-@OptIn(ExperimentalTime::class)
 internal fun Shooter.fireShots(range: Distance, attackDuration: Duration, random: Random): Int {
     val shotsPerDuration = weapon.roundsPerMinute * attackDuration.toDouble(DurationUnit.MINUTES) + partialShot
     // rounding down loses a partial shot that is remember for the next call.

--- a/game/engine/src/main/kotlin/de/gleex/pltcmd/game/engine/entities/types/ElementType.kt
+++ b/game/engine/src/main/kotlin/de/gleex/pltcmd/game/engine/entities/types/ElementType.kt
@@ -4,8 +4,8 @@ import de.gleex.pltcmd.game.engine.attributes.CommandersIntent
 import de.gleex.pltcmd.game.engine.attributes.ElementAttribute
 import de.gleex.pltcmd.game.engine.extensions.AnyGameEntity
 import de.gleex.pltcmd.game.engine.extensions.GameEntity
+import de.gleex.pltcmd.game.engine.extensions.castToSuspending
 import de.gleex.pltcmd.game.engine.extensions.getAttribute
-import de.gleex.pltcmd.game.engine.extensions.tryCastTo
 import de.gleex.pltcmd.model.elements.CallSign
 import de.gleex.pltcmd.model.elements.CommandingElement
 import org.hexworks.amethyst.api.base.BaseEntityType
@@ -40,8 +40,8 @@ internal val ElementEntity.commandersIntent
  *
  * @param R the type that is returned by [whenElement]
  */
-fun <R> AnyGameEntity.asElementEntity(whenElement: (ElementEntity) -> R): R? =
-    tryCastTo<ElementEntity, ElementType, R>(whenElement)
+suspend fun <R> AnyGameEntity.asElementEntity(whenElement: suspend (ElementEntity) -> R): R? =
+    castToSuspending<ElementEntity, ElementType, R>(whenElement)
 
 /**
  * @return true, when this entity is an [ElementEntity].

--- a/game/engine/src/main/kotlin/de/gleex/pltcmd/game/engine/systems/behaviours/IntentPursuing.kt
+++ b/game/engine/src/main/kotlin/de/gleex/pltcmd/game/engine/systems/behaviours/IntentPursuing.kt
@@ -5,7 +5,6 @@ import de.gleex.pltcmd.game.engine.attributes.CommandersIntent
 import de.gleex.pltcmd.game.engine.entities.types.asElementEntity
 import de.gleex.pltcmd.game.engine.entities.types.commandersIntent
 import de.gleex.pltcmd.game.engine.extensions.AnyGameEntity
-import kotlinx.coroutines.runBlocking
 import org.hexworks.amethyst.api.base.BaseBehavior
 
 /**
@@ -16,10 +15,7 @@ object IntentPursuing : BaseBehavior<GameContext>(CommandersIntent::class) {
         return entity.asElementEntity { element ->
             val messageToExecute = element.commandersIntent.proceed(element, context)
             if (messageToExecute != null) {
-                // FIXME: Use surrounding coroutine context (something like entity.receiveWhenElement{ ... }?)
-                runBlocking {
-                    element.receiveMessage(messageToExecute)
-                }
+                element.receiveMessage(messageToExecute)
             }
             messageToExecute != null
         } ?: false

--- a/game/options/src/main/kotlin/de/gleex/pltcmd/game/options/GameConstants.kt
+++ b/game/options/src/main/kotlin/de/gleex/pltcmd/game/options/GameConstants.kt
@@ -2,8 +2,7 @@ package de.gleex.pltcmd.game.options
 
 import de.gleex.pltcmd.model.world.WorldTile
 import de.gleex.pltcmd.util.measure.speed.per
-import kotlin.time.Duration
-import kotlin.time.ExperimentalTime
+import kotlin.time.Duration.Companion.seconds
 
 /**
  * This object holds constant values that are otherwise "just assumed". When doing calculations regarding "fixed" values
@@ -27,8 +26,7 @@ object GameConstants {
         /**
          * The amount of ingame time that passes in one tick.
          */
-        @OptIn(ExperimentalTime::class)
-        val timeSimulatedPerTick = Duration.seconds(60)
+        val timeSimulatedPerTick = 60.seconds
 
     }
 

--- a/game/serialization/src/main/kotlin/de/gleex/pltcmd/game/serialization/world/WorldMapDao.kt
+++ b/game/serialization/src/main/kotlin/de/gleex/pltcmd/game/serialization/world/WorldMapDao.kt
@@ -2,12 +2,6 @@ package de.gleex.pltcmd.game.serialization.world
 
 import de.gleex.pltcmd.model.world.WorldMap
 import de.gleex.pltcmd.model.world.WorldTile
-import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.flow.asFlow
-import kotlinx.coroutines.flow.buffer
-import kotlinx.coroutines.flow.flowOn
-import kotlinx.coroutines.flow.toList
-import kotlinx.coroutines.runBlocking
 import kotlinx.serialization.Serializable
 
 /** Stores/loads map data. */
@@ -22,11 +16,7 @@ data class WorldMapDao(val tiles: Collection<WorldTile>, val name: String = "leg
     companion object {
         /** Returns only the basic data of the map */
         fun of(map: WorldMap, name: String): WorldMapDao {
-            val tilesPerOrigin: MutableList<WorldTile> = mutableListOf()
-            runBlocking {
-                map.allTiles.asFlow().flowOn(Dispatchers.Default).buffer().toList(tilesPerOrigin)
-            }
-            return WorldMapDao(tilesPerOrigin, name)
+            return WorldMapDao(map.allTiles.toList(), name)
         }
     }
 }

--- a/game/ticks/src/main/kotlin/de/gleex/pltcmd/game/ticks/Ticker.kt
+++ b/game/ticks/src/main/kotlin/de/gleex/pltcmd/game/ticks/Ticker.kt
@@ -13,7 +13,6 @@ import java.time.LocalTime
 import java.util.concurrent.Executors
 import java.util.concurrent.TimeUnit
 import kotlin.time.DurationUnit
-import kotlin.time.ExperimentalTime
 import kotlin.time.toDuration
 
 private val log = KotlinLogging.logger {}
@@ -84,7 +83,6 @@ object Ticker {
     /**
      * Increases the current tick, publishes the corresponding [TickEvent].
      */
-    @OptIn(ExperimentalTime::class)
     private fun tick() {
         if(log.isDebugEnabled() && lastTickTimestamp != null) {
             val last = lastTickTimestamp ?: 0

--- a/model/communication/src/main/kotlin/de/gleex/pltcmd/model/radio/communication/RadioContext.kt
+++ b/model/communication/src/main/kotlin/de/gleex/pltcmd/model/radio/communication/RadioContext.kt
@@ -8,5 +8,5 @@ import de.gleex.pltcmd.model.world.coordinate.Coordinate
 interface RadioContext {
     val currentLocation: Coordinate
     fun newTransmissionContext(): TransmissionContext
-    fun executeOrder(order: Conversations.Orders, orderedBy: CallSign, orderedTo: Coordinate?)
+    suspend fun executeOrder(order: Conversations.Orders, orderedBy: CallSign, orderedTo: Coordinate?)
 }

--- a/model/signals/core/src/main/kotlin/de/gleex/pltcmd/model/signals/core/Signal.kt
+++ b/model/signals/core/src/main/kotlin/de/gleex/pltcmd/model/signals/core/Signal.kt
@@ -5,7 +5,6 @@ import de.gleex.pltcmd.model.world.coordinate.Coordinate
 import de.gleex.pltcmd.model.world.coordinate.Coordinate.Companion.compareByDistanceFrom
 import de.gleex.pltcmd.model.world.coordinate.CoordinatePath
 import de.gleex.pltcmd.model.world.terrain.Terrain
-import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.flow.*
 import mu.KotlinLogging
@@ -46,7 +45,6 @@ class Signal<P : SignalPower>(
      *
      * This flow is cancellable.
      */
-    @OptIn(ExperimentalCoroutinesApi::class)
     val all: Flow<Pair<Coordinate, SignalStrength>> by lazy {
         area
             .toSortedSet(compareByDistanceFrom(origin))

--- a/model/world/src/main/kotlin/de/gleex/pltcmd/model/world/WorldMap.kt
+++ b/model/world/src/main/kotlin/de/gleex/pltcmd/model/world/WorldMap.kt
@@ -13,7 +13,6 @@ import kotlin.math.min
 /**
  * The world contains all map tiles. The world is divided into [Sector]s.
  */
-@OptIn(ExperimentalStdlibApi::class)
 class WorldMap private constructor(coordinateGraph: CoordinateGraph, tiles: Map<Coordinate, WorldTile>) {
 
     private constructor(

--- a/util/measure/src/main/kotlin/de/gleex/pltcmd/util/measure/speed/DistanceExtension.kt
+++ b/util/measure/src/main/kotlin/de/gleex/pltcmd/util/measure/speed/DistanceExtension.kt
@@ -3,18 +3,15 @@ package de.gleex.pltcmd.util.measure.speed
 import de.gleex.pltcmd.util.measure.distance.Distance
 import kotlin.time.Duration
 import kotlin.time.DurationUnit
-import kotlin.time.ExperimentalTime
 import kotlin.time.toDuration
 
 /** The [Speed] when traveling this distance in one hour. */
 val Distance.perHour: Speed
-    @OptIn(ExperimentalTime::class)
     get() = Speed(this, 1.toDuration(DurationUnit.HOURS))
 
 /**
  * Infix function to define a [Speed] as `distance per time`. You can also [div] a [Distance] by a [Duration].
  */
-@OptIn(ExperimentalTime::class)
 infix fun Distance.per(time: Duration): Speed = Speed(this, time)
 
 /**
@@ -22,5 +19,4 @@ infix fun Distance.per(time: Duration): Speed = Speed(this, time)
  *
  * @see per
  */
-@OptIn(ExperimentalTime::class)
 operator fun Distance.div(time: Duration) = this per time

--- a/util/measure/src/main/kotlin/de/gleex/pltcmd/util/measure/speed/Speed.kt
+++ b/util/measure/src/main/kotlin/de/gleex/pltcmd/util/measure/speed/Speed.kt
@@ -4,7 +4,6 @@ import de.gleex.pltcmd.util.measure.distance.Distance
 import de.gleex.pltcmd.util.measure.distance.DistanceUnit
 import kotlin.time.Duration
 import kotlin.time.DurationUnit
-import kotlin.time.ExperimentalTime
 import kotlin.time.toDuration
 
 /**
@@ -17,7 +16,6 @@ import kotlin.time.toDuration
  *
  * @param inKph km/h (kilometre per hour)
  */
-@OptIn(ExperimentalTime::class)
 data class Speed internal constructor(val inKph: Double) : Comparable<Speed> {
     internal constructor(distance: Distance, time: Duration) : this(
         distance.inUnit(DistanceUnit.Kilometers) / time.toDouble(

--- a/util/measure/src/test/kotlin/de/gleex/pltcmd/util/measure/speed/SpeedTest.kt
+++ b/util/measure/src/test/kotlin/de/gleex/pltcmd/util/measure/speed/SpeedTest.kt
@@ -5,16 +5,14 @@ import de.gleex.pltcmd.util.measure.distance.kilometers
 import de.gleex.pltcmd.util.measure.distance.meters
 import io.kotest.core.spec.style.StringSpec
 import io.kotest.matchers.shouldBe
-import kotlin.time.Duration
-import kotlin.time.ExperimentalTime
+import kotlin.time.Duration.Companion.minutes
 
-@OptIn(ExperimentalTime::class)
 class SpeedTest : StringSpec({
 
     "constructors/inKph" {
         Speed(13.37).inKph shouldBe 13.37
         13.kilometers.perHour.inKph shouldBe 13.0
-        Speed(3.hundredMeters, Duration.minutes(15)).inKph shouldBe 1.2
+        Speed(3.hundredMeters, 15.minutes).inKph shouldBe 1.2
     }
 
     "times" {
@@ -27,6 +25,6 @@ class SpeedTest : StringSpec({
 
     "equals" {
         7000.meters.perHour shouldBe 7.kilometers.perHour
-        7.kilometers.perHour shouldBe Speed(21.kilometers, Duration.minutes(180))
+        7.kilometers.perHour shouldBe Speed(21.kilometers, 180.minutes)
     }
 })


### PR DESCRIPTION
The investigation mentioned in #136 should be used to fix the usage of coroutines all over the project, especially in `engine`.

We have `runBlocking` calls and other non-idiomatic code in several places and I believe that his makes the game run extremely slow.